### PR TITLE
Add query tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ _export:
     user: snow_user
     warehouse: compute_wh
     # schema: public
+    # query_tag: etl_task_for_xyz123
 
 +run_task:
   snow>: example.sql
@@ -44,6 +45,7 @@ parameter名|必須？|補足|設定可能箇所<br>snow>の直下|設定可能�
 `role`|x|Snowflakeの接続ロール名|o|o|x
 `warehouse`|x|演算が行われる、Snowflakeのウェアハウス名|o|o|x
 `database`|x|セッションに使われるデータベース|o|o|x
+`query_tag`|x|Snowflakeのクエリタグ名|o|o|x
 `schema`|x|セッションに使われるスキーマ|o|o|x
 `create_table`|x|クエリの冒頭にCREATE TABLE {table} AS を付与|o|x|x
 `create_or_replace_table`|x|クエリの冒頭にCREATE OR REPLACE TABLE {table} AS を付与|o|x|x

--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ Artifacts are build on local repos: `~/.m2`.
 ### 2) run an example
 
 ```sh
-rm -rf .digdag/plugin 
+rm -rf .digdag/plugins 
 digdag run example.dig --session daily -a
 ```

--- a/example.dig
+++ b/example.dig
@@ -18,3 +18,4 @@ _export:
     database: TEST_HORI
     schema: public
     create_or_replace_table: hogehoge
+    query_tag: etl_task_for_xyz123

--- a/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowOperator.scala
+++ b/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowOperator.scala
@@ -66,10 +66,9 @@ class SnowOperator(_context: OperatorContext, templateEngine: TemplateEngine) ex
     )
     val stmt = conn.createStatement()
     try {
-      val queryTag = getConfigFromOperatorParameterOrExportedParameterOptional(config, "query_tag").orNull
-      if (queryTag != null) {
-        stmt.execute(s"alter session set QUERY_TAG = $queryTag")
-      }
+      val queryTag = getConfigFromOperatorParameterOrExportedParameterOptional(config, "query_tag")
+      queryTag.foreach(tag => stmt.execute(s"alter session set QUERY_TAG = $tag"))
+
       stmt.execute(sql)
       // オペレータの処理が無事成功した場合はTaskResultを返す
       TaskResult.empty(this.request)

--- a/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowOperator.scala
+++ b/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowOperator.scala
@@ -66,6 +66,10 @@ class SnowOperator(_context: OperatorContext, templateEngine: TemplateEngine) ex
     )
     val stmt = conn.createStatement()
     try {
+      val queryTag = getConfigFromOperatorParameterOrExportedParameterOptional(config, "query_tag").orNull
+      if (queryTag != null) {
+        stmt.execute(s"alter session set QUERY_TAG = $queryTag")
+      }
       stmt.execute(sql)
       // オペレータの処理が無事成功した場合はTaskResultを返す
       TaskResult.empty(this.request)


### PR DESCRIPTION
# 概要

`QUERY_TAG`を設定できるようにしました。

#  どう便利に使えるか？

1. UI上で履歴を追いかけやすくなる
2. クエリ書いて過去クエリをで引っ張りやすくなる。

（1つ目イメージ）  
![image](https://user-images.githubusercontent.com/58797285/127792957-a5e12518-48d7-42cf-8b86-70e5cecbffba.png)

（2つ目イメージ）
![image](https://user-images.githubusercontent.com/58797285/127792589-e36ddeb9-586a-4fac-97df-d71f215ef104.png)

# その他

接続時に設定可能なのかを見てみたものの、`queryTag`のような接続パラメータは存在しないようです。  
（参考）https://docs.snowflake.com/ja/user-guide/jdbc-parameters.html#jdbc-driver-connection-parameter-reference

そのため、愚直に`alter session set QUERY_TAG = $queryTag`しています