### PR TITLE
Feature: add option store_last_results

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ parameter名|必須？|補足|設定可能箇所<br>snow>の直下|設定可能�
 snow>の直下およびexportされた`snow.{parameter}`両方に設定可能なパラメータが、両方に設定されていた場合は、snow>の直下に設定された値を優先して使用する
 
 ### アウトプット一覧
-parameter名|
----|
-ids|
+parameter名|補足
+---|---
+ids|最初の1文および、SELECT文のみIDが取得できます。(CREATE文やINSERT文などはID取得できません。)
 query|
 
 ### `snow.password`シークレット設定例

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ parameter名|必須？|補足|設定可能箇所<br>snow>の直下|設定可能�
 `insert_into`|x|クエリの冒頭にINSERT INTO {table} AS を付与|o|x|x
 `session_unixtime_sql_variable_name`|x|digdagのsession_unixtimeを、Snowflake SQL変数にsetする。その際の変数名|o|o|x
 `multi_queries`|x|複数のクエリを実行可にする(true&#124;false). SQLインジェクションを受ける可能性が高くなるため使用には注意|o|o|x
+`store_last_results`|x|クエリ結果の最初の1行を ${snow.last_results}変数に格納する(true&#124;false)|o|x|x
 
 snow>の直下およびexportされた`snow.{parameter}`両方に設定可能なパラメータが、両方に設定されていた場合は、snow>の直下に設定された値を優先して使用する
 

--- a/example.dig
+++ b/example.dig
@@ -17,7 +17,6 @@ _export:
     snow>: example.sql
     database: TEST_HORI
     schema: public
-    create_or_replace_table: hogehoge
     query_tag: etl_task_for_xyz123
     timezone: Asia/Tokyo
     multi_queries: true

--- a/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowOperator.scala
+++ b/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowOperator.scala
@@ -73,10 +73,10 @@ class SnowOperator(_context: OperatorContext, templateEngine: TemplateEngine) ex
     )
     val stmt = conn.createStatement()
     try {
-      val is_multi_queries = getConfigFromOperatorParameterOrExportedParameterOptional[Boolean](config, "multi_queries").getOrElse(false)
-      val is_store_last_results = getOptionalParameterFromOperatorParameter[Boolean](config, "store_last_results").getOrElse(false)
+      val multiQueries = getConfigFromOperatorParameterOrExportedParameterOptional[Boolean](config, "multi_queries").getOrElse(false)
+      val storeLastResults = getOptionalParameterFromOperatorParameter[Boolean](config, "store_last_results").getOrElse(false)
 
-      if(is_multi_queries) {
+      if(multiQueries) {
         stmt.unwrap(classOf[SnowflakeStatement]).setParameter("MULTI_STATEMENT_COUNT", 0)
       }
 
@@ -95,14 +95,14 @@ class SnowOperator(_context: OperatorContext, templateEngine: TemplateEngine) ex
       for (_ <- 0 until maxStmt) {
         val result = stmt.getResultSet()
         if (result != null) {
-          if (is_store_last_results && !result.isClosed) store = buildStoreParam(result)
+          if (storeLastResults && !result.isClosed) store = buildStoreParam(result)
           queryResults.add(QueryResult(result.unwrap(classOf[SnowflakeResultSet]).getQueryID))
         }
         stmt.getMoreResults
       }
       if (queryResults.isEmpty) { // 全statementにSELECT文が一つもない場合
         queryResults.add(QueryResult(stmt.unwrap(classOf[SnowflakeStatement]).getQueryID))
-        if (is_store_last_results) store.getNestedOrSetEmpty("snow").getNestedOrSetEmpty("last_results")
+        if (storeLastResults) store.getNestedOrSetEmpty("snow").getNestedOrSetEmpty("last_results")
       }
       val output = buildOutputParam(sql, queryResults.toList)
 

--- a/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowOperator.scala
+++ b/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowOperator.scala
@@ -95,7 +95,7 @@ class SnowOperator(_context: OperatorContext, templateEngine: TemplateEngine) ex
       for (_ <- 0 until maxStmt) {
         val result = stmt.getResultSet()
         if (result != null) {
-          if (is_store_last_results) store = buildStoreParam(result)
+          if (is_store_last_results && !result.isClosed) store = buildStoreParam(result)
           queryResults.add(QueryResult(result.unwrap(classOf[SnowflakeResultSet]).getQueryID))
         }
         stmt.getMoreResults

--- a/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowOperator.scala
+++ b/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowOperator.scala
@@ -9,7 +9,7 @@ import net.snowflake.client.jdbc.{SnowflakeDriver, SnowflakeResultSet, Snowflake
 import org.slf4j.LoggerFactory
 
 import java.nio.charset.StandardCharsets.UTF_8
-import java.sql.{Connection, DriverManager}
+import java.sql.{Connection, DriverManager, ResultSet}
 import java.util.Properties
 import scala.reflect.ClassTag
 
@@ -73,7 +73,10 @@ class SnowOperator(_context: OperatorContext, templateEngine: TemplateEngine) ex
     )
     val stmt = conn.createStatement()
     try {
-      if(getConfigFromOperatorParameterOrExportedParameterOptional[Boolean](config, "multi_queries").getOrElse(false)) {
+      val is_multi_queries = getConfigFromOperatorParameterOrExportedParameterOptional[Boolean](config, "multi_queries").getOrElse(false)
+      val is_store_last_results = getOptionalParameterFromOperatorParameter[Boolean](config, "store_last_results").getOrElse(false)
+
+      if(is_multi_queries) {
         stmt.unwrap(classOf[SnowflakeStatement]).setParameter("MULTI_STATEMENT_COUNT", 0)
       }
 
@@ -85,18 +88,28 @@ class SnowOperator(_context: OperatorContext, templateEngine: TemplateEngine) ex
       // そのため実行されたstatement数を正確に数える手段がなく、";"をカウントして代わりとしています。
       // 正確なstatement数がわからないので、loopは可能性のあるstatement数の最大分を回し、さらに重複して抽出したstatementは排除するという考えのもと実装しています。
       val maxStmt = sql.count(_ == ';') + 1
-      val queryResults = collection.mutable.Set(QueryResult(stmt.unwrap(classOf[SnowflakeStatement]).getQueryID))
+      val queryResults = collection.mutable.Set[QueryResult]()
+
+      var store = request.getConfig.getFactory.create()
+
       for (_ <- 0 until maxStmt) {
         val result = stmt.getResultSet()
-        if(result != null)
+        if (result != null) {
+          if (is_store_last_results) store = buildStoreParam(result)
           queryResults.add(QueryResult(result.unwrap(classOf[SnowflakeResultSet]).getQueryID))
+        }
         stmt.getMoreResults
       }
-      val output: Config = buildOutputParam(sql, queryResults.toList)
+      if (queryResults.isEmpty) { // 全statementにSELECT文が一つもない場合
+        queryResults.add(QueryResult(stmt.unwrap(classOf[SnowflakeStatement]).getQueryID))
+        if (is_store_last_results) store.getNestedOrSetEmpty("snow").getNestedOrSetEmpty("last_results")
+      }
+      val output = buildOutputParam(sql, queryResults.toList)
 
       val builder = TaskResult.defaultBuilder(request)
       builder.resetStoreParams(ImmutableList.of(ConfigKey.of("snow", "last_query")))
-      builder.storeParams(output)
+      builder.resetStoreParams(ImmutableList.of(ConfigKey.of("snow", "last_result")))
+      builder.storeParams(output.merge(store))
       builder.build()
     } catch {
       case e: Throwable => throw new TaskExecutionException(e)
@@ -158,13 +171,27 @@ class SnowOperator(_context: OperatorContext, templateEngine: TemplateEngine) ex
     }
   }
 
-  private def buildOutputParam(sql: String, queries: List[QueryResult]): Config =
-  {
+  private def buildOutputParam(sql: String, queries: List[QueryResult]): Config = {
     val ret = request.getConfig.getFactory.create()
     val lastQueryParam = ret.getNestedOrSetEmpty("snow").getNestedOrSetEmpty("last_query")
 
-    lastQueryParam.set("ids", java.util.Arrays.asList(queries.map(_.id) :_*))
+    lastQueryParam.set("ids", java.util.Arrays.asList(queries.map(_.id): _*))
     lastQueryParam.set("query", sql)
+    ret
+  }
+
+  private def buildStoreParam(rs: ResultSet): Config = {
+    val ret = request.getConfig.getFactory.create()
+    val map = new java.util.LinkedHashMap[String, AnyRef]()
+    val metadata = rs.getMetaData
+
+    if(rs.next()) {
+      (1 to metadata.getColumnCount).foreach { i =>
+        map.put(metadata.getColumnName(i), rs.getObject(i))
+      }
+    }
+
+    ret.getNestedOrSetEmpty("snow").set("last_results", map)
     ret
   }
 }

--- a/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowPlugin.scala
+++ b/src/main/scala/dev/hiro_hori/digdag_operator_snowflake/SnowPlugin.scala
@@ -1,8 +1,8 @@
 package dev.hiro_hori.digdag_operator_snowflake
 
-import java.util
 import io.digdag.spi.{OperatorFactory, OperatorProvider, Plugin, TemplateEngine}
 
+import java.util
 import javax.inject.Inject
 class SnowPlugin extends Plugin {
   override def getServiceProvider[T](`type`: Class[T]): Class[_ <: T] =


### PR DESCRIPTION
## 変更内容
- store_last_resultsオプションを追加し、クエリ結果の最初の1行を取得できるようにした


### 実行サンプル
以下のwfを実行しました 

```test.dig
timezone: Asia/Tokyo

_export:
  plugin:
    repositories:
    - https://jitpack.io
    dependencies:
    - com.github.kanaeta:digdag_operator_snowflake:v0.1.2-SNAPSHOT
  snow:
    host: vx58248.ap-northeast-1.aws.snowflakecomputing.com
    user: DIGDAGPLUGIN
    warehouse: COMPUTE_WH
    database: TEST
    schema: PUBLIC
    query_tag: TEST1,TEST2

+test1:
  snow>:
  multi_queries: true
  store_last_results: true
  # 複数クエリを実行した場合に、最後のselect文のデータが戻り値になること
  # 複数クエリを実行した場合に、以前のカラム名が紛れ込まないこと
  # 2行以上の場合に、最初の1行目が戻り値になっていること
  query: |
    CREATE TEMPORARY TABLE TEST1 (a VARCHAR, b BIGINT);
    INSERT INTO TEST1 (a, b) VALUES ('a',1);
    SELECT * FROM TEST1;
    
    CREATE OR REPLACE TABLE TEST2 (col1 VARCHAR, col2 BIGINT);
    INSERT INTO TEST2 (col1, col2) VALUES ('b',2),('c',3);
    SELECT * FROM TEST2;
    INSERT INTO TEST2 (col1, col2) VALUES ('d',4);

+test2:
  snow>:
  # last_resultが存在しないこと
  query: SELECT 3 c

+test3:
  snow>:
  store_last_results: true
  # 値が{}で格納されること
  query: |
    INSERT INTO TEST2 (col1, col2) VALUES ('e',5);

+test4:
  snow>:
  store_last_results: true
  # 値が{'NULL': null}で格納されること
  query: |
    select null
    
+test5:
  snow>:
  store_last_results: true
  # 値が{}で格納されること
  query: |
    select 1 LIMIT 0
    
+test6:
  snow>:
  store_last_results: true
  # 全ての型に対応していること
  # @see https://docs.snowflake.com/ja/sql-reference/intro-summary-data-types
  query: |
    select
      NULL,
      NULL::BIGINT,
      1,
      0.0,
      -2::DOUBLE,
      '2',
      TO_BINARY(HEX_ENCODE('2')),
      true::BOOLEAN,
      CURRENT_DATE,
      '23:59:59.99999999'::TIME,
      CURRENT_TIMESTAMP,
      '2023-01-01 01:01:01+01:00'::TIMESTAMP_LTZ,
      '2023-01-01 01:01:01+01:00'::TIMESTAMP_NTZ,
      '2023-01-01 01:01:01+01:00'::TIMESTAMP_TZ,
      TO_VARIANT(PARSE_JSON('{"key3": 1, "key4": "1", "key5": NULL}')),
      OBJECT_CONSTRUCT(
        'name', 'Jones'::VARIANT,
        'age',  NULL::VARIANT,
        'obj', TO_VARIANT(PARSE_JSON('{"key3": 1, "key4": "1"}'))
      ),
      [TO_VARIANT(PARSE_JSON('{"key3": 1, "key4": "1"}')), NULL, 2]::ARRAY,
      TO_GEOGRAPHY('POINT(13.4814 52.5015)'),
      TO_GEOMETRY('POINT(13.4814 52.5015)')
    
+test7:
  snow>:
  store_last_results: true
  # カラム名が被った場合は、一つしか格納されないこと
  query: |
    select
      1   a,
      'b' a
    
+test8:
  snow>:
  store_last_results: true
  # カラム名が被った場合は、最後のカラムが戻り値として反映されること
  query: |
    select
      'b' a,
      1   a
```


#### +test1タスクの戻り値
```
snow:
  last_query:
    ids:
      - 01aae86d-0000-c9ba-0000-0000d5c9306d
      - 01aae86d-0000-c9ba-0000-0000d5c93079
    query: |
      CREATE TEMPORARY TABLE TEST1 (a VARCHAR, b BIGINT);
      INSERT INTO TEST1 (a, b) VALUES ('a',1);
      SELECT * FROM TEST1;

      CREATE OR REPLACE TABLE TEST2 (col1 VARCHAR, col2 BIGINT);
      INSERT INTO TEST2 (col1, col2) VALUES ('b',2),('c',3);
      SELECT * FROM TEST2;
      INSERT INTO TEST2 (col1, col2) VALUES ('d',4);
  last_results:
    COL1: b
    COL2: 2
```
 ##### [挙動1] 複数クエリを実行した場合に、最後のselect文のデータが戻り値になること
`SELECT * FROM TEST1;` ではなく、`SELECT * FROM TEST2;` の結果が反映されています。

また最後クエリ`INSERT INTO TEST2 (col1, col2) VALUES ('d',4);`はSELECT文でないのでlast_resultsの結果としては無視されています。
 ##### [挙動2] 複数クエリを実行した場合に、以前のカラム名が紛れ込まないこと
`SELECT * FROM TEST1;` で生じるカラム名`a`,`b`がlast_resultsには入ってきてません。

 ##### [挙動3] 2行以上の場合に、最初の1行目が戻り値になっていること
last_resultsには('c',3)ではなく、(’b',2)が格納されています。

#### +test2タスクの戻り値

```
snow:
  last_query:
    ids:
      - 01aae86d-0000-c9ba-0000-0000d5c93081
    query: SELECT 3 c
```
##### [挙動4]store_last_resultsが指定されてない場合、last_resultが存在しないこと
store_last_resultsが指定されてない場合の挙動になります。

last_resultsがなく、test1タスクの実行結果がリセットされています。

#### +test3タスクの戻り値
```
snow:
  last_query:
    ids:
      - 01aae86d-0000-c9ba-0000-0000d5c93085
    query: |
      INSERT INTO TEST2 (col1, col2) VALUES ('e',5);
  last_results: {}
```

 ##### [挙動5] SELECT文がない場合、値が{}で格納されること
SELECT文がないので、last_resultsの値は、JSONのemptyオブジェクトが格納されます。

#### +test4タスクの戻り値
```
snow:
  last_query:
    ids:
      - 01aae86d-0000-c9ba-0000-0000d5c93089
    query: |
      select null
  last_results:
    'NULL': null
```

##### [挙動6] SELECT NULLは、{<<フィールド名>>: null}で格納されること
SELECTの結果、1レコード存在するのでそれがlast_resultsに格納されます。

#### +test5タスクの戻り値
```
snow:
  last_query:
    ids:
      - 01aae86d-0000-c9bb-0000-0000d5c9204d
    query: |
      select 1 LIMIT 0
  last_results: {}
```
##### [挙動7] SELECT結果がない場合は、値が{}で格納されること
SELECTの結果、レコードが存在しないのでJSONのemptyオブジェクトが格納されます。

#### +test6タスクの戻り値
```
snow:
  last_query:
    ids:
      - 01aae86d-0000-c9ba-0000-0000d5c9308d
    query: |
      select
        NULL,
        NULL::BIGINT,
        1,
        0.0,
        -2::DOUBLE,
        '2',
        TO_BINARY(HEX_ENCODE('2')),
        true::BOOLEAN,
        CURRENT_DATE,
        '23:59:59.99999999'::TIME,
        CURRENT_TIMESTAMP,
        '2023-01-01 01:01:01+01:00'::TIMESTAMP_LTZ,
        '2023-01-01 01:01:01+01:00'::TIMESTAMP_NTZ,
        '2023-01-01 01:01:01+01:00'::TIMESTAMP_TZ,
        TO_VARIANT(PARSE_JSON('{"key3": 1, "key4": "1", "key5": NULL}')),
        OBJECT_CONSTRUCT(
          'name', 'Jones'::VARIANT,
          'age',  NULL::VARIANT,
          'obj', TO_VARIANT(PARSE_JSON('{"key3": 1, "key4": "1"}'))
        ),
        [TO_VARIANT(PARSE_JSON('{"key3": 1, "key4": "1"}')), NULL, 2]::ARRAY,
        TO_GEOGRAPHY('POINT(13.4814 52.5015)'),
        TO_GEOMETRY('POINT(13.4814 52.5015)')
  last_results:
    '''2''': '2'
    '''2023-01-01 01:01:01+01:00''::TIMESTAMP_LTZ': 1672531261000
    '''2023-01-01 01:01:01+01:00''::TIMESTAMP_NTZ': 1672534861000
    '''2023-01-01 01:01:01+01:00''::TIMESTAMP_TZ': 1672531261000
    '''23:59:59.99999999''::TIME': 86399999
    '-2::DOUBLE': -2
    '0.0': 0
    '1': 1
    CURRENT_DATE: 1678665600000
    CURRENT_TIMESTAMP: 1678670248017
    'NULL': null
    'NULL::BIGINT': null
    "OBJECT_CONSTRUCT(\n    'NAME', 'JONES'::VARIANT,\n    'AGE',  NULL::VARIANT,\n    'OBJ', TO_VARIANT(PARSE_JSON('{\"KEY3\": 1, \"KEY4\": \"1\"}'))\n  )": |-
      {
        "name": "Jones",
        "obj": {
          "key3": 1,
          "key4": "1"
        }
      }
    TO_BINARY(HEX_ENCODE('2')): Mg==
    TO_GEOGRAPHY('POINT(13.4814 52.5015)'): |-
      {
        "coordinates": [
          13.4814,
          52.5015
        ],
        "type": "Point"
      }
    TO_GEOMETRY('POINT(13.4814 52.5015)'): |-
      {
        "coordinates": [
          1.348140000000000e+01,
          5.250150000000000e+01
        ],
        "type": "Point"
      }
    'TO_VARIANT(PARSE_JSON(''{"KEY3": 1, "KEY4": "1", "KEY5": NULL}''))': |-
      {
        "key3": 1,
        "key4": "1",
        "key5": null
      }
    'TRUE::BOOLEAN': true
    '[TO_VARIANT(PARSE_JSON(''{"KEY3": 1, "KEY4": "1"}'')), NULL, 2]::ARRAY': |-
      [
        {
          "key3": 1,
          "key4": "1"
        },
        undefined,
        2
      ]
```

 ##### [挙動8] 全ての型に対応していること
 [snowflakeの型](https://docs.snowflake.com/ja/sql-reference/intro-summary-data-types)

戻り値は、フィールド名順にソートされます。digdagで使う場合は、${snow.last_result.<<フィールド名>>}で参照すると思うので、問題にはならないと思います。

0.0は0になります。

TIME/DATE/TIMESTAMPは数値になるようです。

半構造化データ型のnullは一部undefinedに変換されてますね。ちょっと条件はよくわかりません..

地理空間データ型も特殊な戻り値になりますね

#### +test7タスクの戻り値
```
snow:
  last_query:
    ids:
      - 01aae86d-0000-c9bb-0000-0000d5c92051
    query: |
      select
        1   a,
        'b' a
  last_results:
    A: b
```
##### [挙動9] カラム名が被った場合は、一つしか格納されないこと
フィールド名が被ると片方は無視されます。

#### +test8タスクの戻り値
```
snow:
  last_query:
    ids:
      - 01aae86d-0000-c9ba-0000-0000d5c93091
    query: |-
      select
        'b' a,
        1   a
  last_results:
    A: 1
```

##### [挙動10] カラム名が被った場合は、最後のカラムが戻り値として反映されること
test7とフィールド順を入れ替えました。

last_resultsに反映されるのは、最後のフィールドとなります。


### 補足

#### td.last_job.num_records相当のものに関して

こちらに関しては実装しませんでした。

理由に関しては以下です。
1. パーフォマンスの問題
JDBCでレコード数を取得する関数はありませんでした。
`resultSet.last()`で最終行にジャンプする関する関数はあるのですが、snowflakeは未実装でエラーとなります。
そうすると行数をカウントするのは、イテレートで総なめすることになるのですが、発行する全クエリでそれを行うのはパフォーマンス的にどうかと思いました。

2. 代替手段の存在
 パフォーマンスが問題なら、store_num_recordsなどのオプションで取得する可にする手もありますが、今回store_last_resultsを実装したので、オプションでの取得ならそちらで代用できるようになりました。
(行数を知りたいなら select count(*)があるし、単にレコード有無の確認だけなら `${Object.keys(snow.last_results).length > 0}` が利用できる)


#### テストに関して

今回挙動に関しては色々選択肢があるので、テスト実装したかったのですが、相変わらず力不足&時間補足で実装できませんでした、すみません :bow:
